### PR TITLE
Require 'enable_midlrt'; CMake function overriding only works once

### DIFF
--- a/Support/MidlRT.cmake
+++ b/Support/MidlRT.cmake
@@ -91,8 +91,7 @@ _generateMdMergePlatformResponseFile()
 #----------------------------------------------------------------------------------------------------------------------
 #
 #----------------------------------------------------------------------------------------------------------------------
-function(add_library)
-    _add_library(${ARGV})
+function(enable_midlrt)
     cmake_language(EVAL CODE "cmake_language(DEFER CALL _process_target_midl [[${ARGV0}]])")
 endfunction()
 

--- a/example/RuntimeComponent/CMakeLists.txt
+++ b/example/RuntimeComponent/CMakeLists.txt
@@ -21,3 +21,5 @@ target_precompile_headers(RuntimeComponent
     PRIVATE
         pch.h
 )
+
+enable_midlrt(RuntimeComponent)


### PR DESCRIPTION
This PR addresses #6: Rather than overriding `add_library` - which turns out to be a bit dangerous - an explicit call to `enable_midlrt(<target>)` is necessary to add MidlRT support.