### PR TITLE
Add 'nuget.config' to avoid external dependencies

### DIFF
--- a/example/nuget.config
+++ b/example/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <clear />
+        <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
+    </packageSources>
+</configuration>


### PR DESCRIPTION
Without a `nuget.config` the build is dependent on user configuration. By adding a `nuget.config` to the root of the build, the configuration is contained in the source.