### PR TITLE
Download Ninja from within the CMake build as necessary

### DIFF
--- a/Ninja.cmake
+++ b/Ninja.cmake
@@ -1,0 +1,84 @@
+#----------------------------------------------------------------------------------------------------------------------
+# MIT License
+#
+# Copyright (c) 2021 Mark Schofield
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#----------------------------------------------------------------------------------------------------------------------
+#
+# Downloads the Ninja Build executable from within a toolchain.
+#
+# The following variables can be used to configure the behavior of this file:
+#
+# | CMake Variable          | Description                                                                                                               |
+# |-------------------------|---------------------------------------------------------------------------------------------------------------------------|
+# | NINJA_VERSION           | The version of Ninja to download - if it can't be found. Defaults to 1.10.2.                                              |
+# | NINJA_ARCHIVE_HASH      | The hash of the Ninja archive, following the format of `string(<HASH>`. Defaults to the hash of the Ninja 1.10.2 archive. |
+# | TOOLCHAIN_TOOLS_PATH    | The path to download tools to. If not set, then tools will not be downloaded.                                             |
+include_guard()
+
+if((NOT (CMAKE_GENERATOR STREQUAL Ninja)) AND (NOT (CMAKE_GENERATOR STREQUAL "Ninja Multi-Config")))
+    return()
+endif()
+
+if(NOT NINJA_VERSION)
+    set(NINJA_VERSION "1.10.2")
+    set(NINJA_ARCHIVE_HASH "SHA256=BBDE850D247D2737C5764C927D1071CBB1F1957DCABDA4A130FA8547C12C695F")
+else()
+    if(NOT NINJA_ARCHIVE_HASH)
+        message(FATAL_ERROR "NINJA_VERSION is set to ${NINJA_VERSION}. NINJA_ARCHIVE_HASH must be set if NINJA_VERSION is set.")
+    endif()
+endif()
+
+find_program(NINJA_PATH
+    ninja ninja.exe
+    PATHS
+        ${NINJA_PATH}
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/ToolchainCommon.cmake")
+
+# If:
+#   1. Ninja can't be found
+#   2. TOOLCHAIN_TOOLS_PATH is set
+#   3. CMAKE_MAKE_PROGRAM isn't specified, or it was specified and equal to where it would be downloaded to.
+#
+# Download and unpack ninja to TOOLCHAIN_TOOLS_PATH and set CMAKE_MAKE_PROGRAM to point to it.
+if((NINJA_PATH STREQUAL "NINJA_PATH-NOTFOUND") AND TOOLCHAIN_TOOLS_PATH)
+    set(NINJA_ARCHIVE_PATH "${TOOLCHAIN_TOOLS_PATH}/ninja.zip")
+    set(NINJA_PATH "${TOOLCHAIN_TOOLS_PATH}/ninja.exe")
+
+    if ((NOT CMAKE_MAKE_PROGRAM) OR (CMAKE_MAKE_PROGRAM STREQUAL NINJA_PATH))
+        toolchain_download_file(
+            URL "https://github.com/ninja-build/ninja/releases/download/v${NINJA_VERSION}/ninja-win.zip"
+            PATH ${NINJA_ARCHIVE_PATH}
+            EXPECTED_HASH ${NINJA_ARCHIVE_HASH}
+        )
+
+        if(${NINJA_ARCHIVE_PATH} IS_NEWER_THAN ${NINJA_PATH})
+            file(ARCHIVE_EXTRACT
+                INPUT ${NINJA_ARCHIVE_PATH}
+                DESTINATION ${TOOLCHAIN_TOOLS_PATH}
+            )
+            file(TOUCH_NOCREATE ${NINJA_PATH})
+        endif()
+
+        set(CMAKE_MAKE_PROGRAM ${NINJA_PATH} CACHE FILEPATH "" FORCE)
+    endif()
+endif()

--- a/ToolchainCommon.cmake
+++ b/ToolchainCommon.cmake
@@ -1,0 +1,90 @@
+#----------------------------------------------------------------------------------------------------------------------
+# MIT License
+#
+# Copyright (c) 2021 Mark Schofield
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#----------------------------------------------------------------------------------------------------------------------
+include_guard()
+
+#[[====================================================================================================================
+    toolchain_update_file
+    ---------------------
+    Updates the file at the given path to have the given contents. If the contents already match, then the file is not
+    touched.
+
+        toolchain_update_file(
+            PATH <file path>
+            CONTENT <content>
+        )
+====================================================================================================================]]#
+function(toolchain_update_file)
+    set(OPTIONS)
+    set(ONE_VALUE_KEYWORDS CONTENT PATH)
+    set(MULTI_VALUE_KEYWORDS)
+
+    cmake_parse_arguments(PARSE_ARGV 0 UPDATE_FILE "${OPTIONS}" "${ONE_VALUE_KEYWORDS}" "${MULTI_VALUE_KEYWORDS}")
+
+    if(NOT (EXISTS ${UPDATE_FILE_PATH}))
+        message(VERBOSE "update_file: Creating ${UPDATE_FILE_PATH}")
+        file(WRITE ${UPDATE_FILE_PATH} ${UPDATE_FILE_CONTENT})
+    else()
+        file(READ ${UPDATE_FILE_PATH} CURRENT_CONTENT)
+        if(NOT (CURRENT_CONTENT STREQUAL UPDATE_FILE_CONTENT))
+            message(VERBOSE "update_file: Updating ${UPDATE_FILE_PATH}")
+            file(WRITE ${UPDATE_FILE_PATH} ${UPDATE_FILE_CONTENT})
+        endif()
+    endif()
+endfunction()
+
+#[[====================================================================================================================
+    toolchain_download_file
+    -----------------------
+    Downloads a file to the given path.
+
+        toolchain_download_file(
+            URL <url>
+            PATH <file path>
+            EXPECTED_HASH <algorithm>=<hash>
+        )
+
+    The URL and EXPECTED_HASH values will be written to "<file path>.key" forcing a re-download if the values change.
+====================================================================================================================]]#
+function(toolchain_download_file)
+    set(OPTIONS)
+    set(ONE_VALUE_KEYWORDS URL PATH EXPECTED_HASH)
+    set(MULTI_VALUE_KEYWORDS)
+
+    cmake_parse_arguments(PARSE_ARGV 0 DOWNLOAD_FILE "${OPTIONS}" "${ONE_VALUE_KEYWORDS}" "${MULTI_VALUE_KEYWORDS}")
+
+    toolchain_update_file(
+        PATH "${DOWNLOAD_FILE_PATH}.key"
+        CONTENT "URL ${DOWNLOAD_FILE_URL}:EXPECTED_HASH ${DOWNLOAD_FILE_EXPECTED_HASH}"
+    )
+
+    if("${DOWNLOAD_FILE_PATH}.key" IS_NEWER_THAN ${DOWNLOAD_FILE_PATH})
+        message(VERBOSE "download_file: ${DOWNLOAD_FILE_URL} --> ${DOWNLOAD_FILE_PATH}")
+        file(REMOVE ${DOWNLOAD_FILE_PATH})
+        file(DOWNLOAD
+            ${DOWNLOAD_FILE_URL}
+            ${DOWNLOAD_FILE_PATH}
+            EXPECTED_HASH ${DOWNLOAD_FILE_EXPECTED_HASH}
+        )
+    endif()
+endfunction()

--- a/Windows.Clang.toolchain.cmake
+++ b/Windows.Clang.toolchain.cmake
@@ -69,6 +69,7 @@ if(NOT CMAKE_VS_VERSION_PRERELEASE)
     set(CMAKE_VS_VERSION_PRERELEASE OFF)
 endif()
 
+include("${CMAKE_CURRENT_LIST_DIR}/Ninja.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/NuGet.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/VSWhere.cmake")
 

--- a/Windows.MSVC.toolchain.cmake
+++ b/Windows.MSVC.toolchain.cmake
@@ -72,6 +72,7 @@ set(CMAKE_CROSSCOMPILING TRUE)
 set(WIN32 1)
 set(MSVC 1)
 
+include("${CMAKE_CURRENT_LIST_DIR}/Ninja.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/NuGet.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/VSWhere.cmake")
 

--- a/example/CMakePresets.json
+++ b/example/CMakePresets.json
@@ -10,6 +10,7 @@
       "name": "windows",
       "hidden": true,
       "cacheVariables": {
+        "TOOLCHAIN_TOOLS_PATH": "${sourceDir}/__tools",
         "NUGET_PACKAGE_ROOT_PATH": "${sourceDir}/__packages",
         "NUGET_PATH": "${sourceDir}/__tools/nuget.exe",
         "CPPWINRT_VERSION": "2.0.210930.14",
@@ -25,10 +26,6 @@
       "description": "This build is only available on Windows",
       "generator": "Ninja Multi-Config",
       "cacheVariables": {
-        "CMAKE_MAKE_PROGRAM": {
-          "type": "STRING",
-          "value": "${sourceDir}/__tools/ninja/ninja.exe"
-        },
         "CMAKE_TOOLCHAIN_FILE": "../Windows.MSVC.toolchain.cmake",
         "CMAKE_VS_VERSION_PRERELEASE": "ON"
       },
@@ -42,10 +39,6 @@
       "description": "This build is only available on Windows",
       "generator": "Ninja Multi-Config",
       "cacheVariables": {
-        "CMAKE_MAKE_PROGRAM": {
-          "type": "STRING",
-          "value": "${sourceDir}/__tools/ninja/ninja.exe"
-        },
         "CMAKE_TOOLCHAIN_FILE": "../Windows.Clang.toolchain.cmake",
         "CMAKE_VS_VERSION_RANGE": "[16.0,18.0)",
         "CMAKE_VS_VERSION_PRERELEASE": "ON"

--- a/example/README.md
+++ b/example/README.md
@@ -11,7 +11,7 @@ From a PowerShell Core command prompt, run:
 ./initialize.ps1
 ```
 
-to download 'ninja.exe'. Then run:
+to download 'nuget.exe'. Then run:
 
 ```pwsh
 ./build.ps1

--- a/example/initialize.ps1
+++ b/example/initialize.ps1
@@ -49,26 +49,6 @@ $ToolsPath = Join-Path -Path $SourcePath -ChildPath __tools
 
 CreateDirectory $ToolsPath
 
-# Get Ninja
-$NinjaVersion = '1.10.2'
-$NinjaArchivePath = Join-Path -Path $ToolsPath -ChildPath 'ninja-win.zip'
-$NinjaArchiveSha256Hash = 'BBDE850D247D2737C5764C927D1071CBB1F1957DCABDA4A130FA8547C12C695F'
-$NinjaOutputPath = Join-Path -Path $ToolsPath -ChildPath 'ninja'
-$NinjaExecutablePath = Join-Path -Path $NinjaOutputPath -ChildPath 'ninja.exe'
-
-if (-not (IsUpToDate $NinjaExecutablePath $NinjaArchivePath)) {
-    Write-Output "Installing Ninja $NinjaVersion"
-    if (-not (IsUpToDate $NinjaArchivePath)) {
-        DownloadFile "https://github.com/ninja-build/ninja/releases/download/v$NinjaVersion/ninja-win.zip" $NinjaArchivePath
-        if ($NinjaArchiveSha256Hash -ne (Get-FileHash -Path $NinjaArchivePath -Algorithm SHA256).Hash) {
-            Remove-Item -Force -Path $NinjaArchivePath
-            Write-Error "Invalid Hash"
-        }
-    }
-    Expand-Archive -Path $NinjaArchivePath -DestinationPath $NinjaOutputPath -Force
-    Touch $NinjaExecutablePath
-}
-
 # Get NuGet
 $NuGetVersion = '6.0.0'
 $NuGetUrl = "https://dist.nuget.org/win-x86-commandline/v$NuGetVersion/nuget.exe"


### PR DESCRIPTION
CMake doesn't need the 'CMAKE_MAKE_PROGRAM' to be available until it encounters a 'project' node. Which means that a Toolchain can download the CMAKE_MAKE_PROGRAM to minimize the 'pre-CMake' build steps. This PR adds support to download (for Windows only at the minute!) Ninja if a Ninja generator is being used. The script needs to be told where to download to - by setting the 'TOOLCHAIN_TOOLS_PATH' variable - and if the variable isn't set, then minimal work is performed.