### PR TITLE
Add support for Spectre mitigations

### DIFF
--- a/Windows.MSVC.toolchain.cmake
+++ b/Windows.MSVC.toolchain.cmake
@@ -37,6 +37,7 @@
 # | CMAKE_VS_PLATFORM_TOOLSET_VERSION           | The version of the MSVC toolset to use. For example, 14.29.30133. Defaults to the highest available.                     |
 # | CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE | The architecture of the toolset to use. Defaults to 'x64'.                                                               |
 # | CMAKE_WINDOWS_KITS_10_DIR                   | The location of the root of the Windows Kits 10 directory.                                                               |
+# | VS_USE_SPECTRE_MITIGATION_RUNTIME           | Whether the compiler should link with a runtime that uses 'Spectre' mitigations. Defaults to 'OFF'.                      |
 #
 # The toolchain file will set the following variables:
 #
@@ -94,6 +95,10 @@ endif()
 
 if(NOT CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE)
     set(CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE x64)
+endif()
+
+if(NOT VS_USE_SPECTRE_MITIGATION_RUNTIME)
+    set(VS_USE_SPECTRE_MITIGATION_RUNTIME OFF)
 endif()
 
 # Find Visual Studio
@@ -161,9 +166,19 @@ endif()
 # Compiler
 include_directories(SYSTEM "${VS_TOOLSET_PATH}/ATLMFC/include")
 include_directories(SYSTEM "${VS_TOOLSET_PATH}/include")
-link_directories("${VS_TOOLSET_PATH}/ATLMFC/lib/${CMAKE_SYSTEM_PROCESSOR}")
-link_directories("${VS_TOOLSET_PATH}/lib/${CMAKE_SYSTEM_PROCESSOR}")
+
+if(VS_USE_SPECTRE_MITIGATION_RUNTIME)
+    set(TOOLCHAIN_SPECTRE_TOKEN "/spectre")
+else()
+    set(TOOLCHAIN_SPECTRE_TOKEN)
+endif()
+
+link_directories("${VS_TOOLSET_PATH}/ATLMFC/lib${TOOLCHAIN_SPECTRE_TOKEN}/${CMAKE_SYSTEM_PROCESSOR}")
+link_directories("${VS_TOOLSET_PATH}/lib${TOOLCHAIN_SPECTRE_TOKEN}/${CMAKE_SYSTEM_PROCESSOR}")
+
 link_directories("${VS_TOOLSET_PATH}/lib/x86/store/references")
 
 # Windows Kits
 include("${CMAKE_CURRENT_LIST_DIR}/Windows.Kits.cmake")
+
+set(TOOLCHAIN_SPECTRE_TOKEN)

--- a/example/CMakePresets.json
+++ b/example/CMakePresets.json
@@ -27,7 +27,8 @@
       "generator": "Ninja Multi-Config",
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": "../Windows.MSVC.toolchain.cmake",
-        "CMAKE_VS_VERSION_PRERELEASE": "ON"
+        "CMAKE_VS_VERSION_PRERELEASE": "ON",
+        "VS_USE_SPECTRE_MITIGATION_RUNTIME": "ON"
       },
       "binaryDir": "${sourceDir}/__output/${presetName}"
     },


### PR DESCRIPTION
Adding support for Spectre mitigations. Since Spectre mitigations need a compiler option **_and_** a custom link path, adding support in the toolchain seems reasonable. TBH, adding better defaults for security mitigations (i.e. `/guard:cf`, `/sdl`, `/CETCOMPAT` and a higher warning level) would probably be a good idea. Thoughts?

This addresses #13.

----
I switched to just controlling the use of the runtime with Spectre mitigations enabled - which seems to be more appropriate for the toolchain. Setting VS_USE_SPECTRE_MITIGATION_RUNTIME to be on/true will cause the toolchain to link with the runtime with Spectre mitigations. It defaults to OFF. This means that the mitigations (and associated performance affects) are off by default, and the expectation would be that if the runtime is being used to manipulate data that crosses a trust boundary, consumers would turn it ON.


