### PR TITLE
Add support for non-WinRT Midl

### DIFF
--- a/Support/Midl.cmake
+++ b/Support/Midl.cmake
@@ -1,0 +1,128 @@
+#----------------------------------------------------------------------------------------------------------------------
+# MIT License
+#
+# Copyright (c) 2021 Mark Schofield
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#----------------------------------------------------------------------------------------------------------------------
+include_guard()
+
+set(MIDL_1_0_PLATFORM_RESPONSE_FILE "${CMAKE_BINARY_DIR}/midl.1.0.platform.rsp")
+
+#----------------------------------------------------------------------------------------------------------------------
+#
+#----------------------------------------------------------------------------------------------------------------------
+function(enable_midl)
+    cmake_language(EVAL CODE "cmake_language(DEFER CALL _process_target_midl_1_0 [[${ARGV0}]])")
+endfunction()
+
+#----------------------------------------------------------------------------------------------------------------------
+#
+#----------------------------------------------------------------------------------------------------------------------
+function(_generateMidlOutput TARGET IDL_FILES MIDL_GENERATED_FILES)
+    get_target_property(TARGET_SOURCE_DIR ${TARGET} SOURCE_DIR)
+    get_target_property(TARGET_INCLUDE_DIRECTORIES ${TARGET} INCLUDE_DIRECTORIES)
+
+    set(MIDL_COMMAND "")
+    list(APPEND MIDL_COMMAND "\"${MIDL_COMPILER}\"")
+    list(APPEND MIDL_COMMAND /nologo)
+    list(APPEND MIDL_COMMAND /W3 /WX)
+    list(APPEND MIDL_COMMAND /char signed)
+    list(APPEND MIDL_COMMAND /env x64)
+    list(APPEND MIDL_COMMAND /error all)
+    list(APPEND MIDL_COMMAND /newtlb)
+    list(APPEND MIDL_COMMAND /robust)
+    list(APPEND MIDL_COMMAND /target NT60)
+    list(APPEND MIDL_COMMAND /dlldata "DllData.c")
+    list(APPEND MIDL_COMMAND /out "\"${CMAKE_CURRENT_BINARY_DIR}/Generated Files\"")
+
+    list(TRANSFORM TARGET_INCLUDE_DIRECTORIES PREPEND "/I \"")
+    list(TRANSFORM TARGET_INCLUDE_DIRECTORIES APPEND "\"")
+    list(APPEND MIDL_COMMAND ${TARGET_INCLUDE_DIRECTORIES})
+
+    # COMPILER_DIR
+    get_filename_component(COMPILER_DIR ${CMAKE_C_COMPILER} DIRECTORY)
+
+    set(GENERATED_FILES)
+    list(APPEND GENERATED_FILES "${CMAKE_CURRENT_BINARY_DIR}/Generated Files/DllData.c")
+
+    foreach(IDL_FILE IN LISTS IDL_FILES)
+        get_filename_component(IDL_FILE_BASE ${IDL_FILE} NAME_WLE)
+
+        set(MIDL_FILE_SPECIFIC_COMMAND ${MIDL_COMMAND})
+        list(APPEND MIDL_FILE_SPECIFIC_COMMAND /h "${IDL_FILE_BASE}_i.h")
+        list(APPEND MIDL_FILE_SPECIFIC_COMMAND /iid "${IDL_FILE_BASE}_i.c")
+        list(APPEND MIDL_FILE_SPECIFIC_COMMAND /proxy "${IDL_FILE_BASE}_p.c")
+        list(APPEND MIDL_FILE_SPECIFIC_COMMAND /tlb "${IDL_FILE_BASE}.tlb")
+        list(APPEND MIDL_FILE_SPECIFIC_COMMAND ${IDL_FILE})
+
+        set(MIDL_OUTPUT_FILES)
+        list(APPEND MIDL_OUTPUT_FILES "${CMAKE_CURRENT_BINARY_DIR}/Generated Files/${IDL_FILE_BASE}_i.h")
+        list(APPEND MIDL_OUTPUT_FILES "${CMAKE_CURRENT_BINARY_DIR}/Generated Files/${IDL_FILE_BASE}_i.c")
+        list(APPEND MIDL_OUTPUT_FILES "${CMAKE_CURRENT_BINARY_DIR}/Generated Files/${IDL_FILE_BASE}_p.c")
+        list(APPEND MIDL_OUTPUT_FILES "${CMAKE_CURRENT_BINARY_DIR}/Generated Files/${IDL_FILE_BASE}.tlb")
+
+        set(MIDL_COMMAND_SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/midl.1.0.${IDL_FILE_BASE}.cmd)
+        list(JOIN MIDL_FILE_SPECIFIC_COMMAND " " MIDL_COMMAND_LINE)
+
+        file(GENERATE OUTPUT ${MIDL_COMMAND_SCRIPT} CONTENT "\
+@echo off
+set PATH=%PATH%;${COMPILER_DIR}
+${MIDL_COMMAND_LINE}
+")
+
+        add_custom_command(
+            OUTPUT ${MIDL_OUTPUT_FILES} "${CMAKE_CURRENT_BINARY_DIR}/Generated Files/DllData.c"
+            COMMAND ${MIDL_COMMAND_SCRIPT}
+            MAIN_DEPENDENCY ${IDL_FILE}
+            DEPENDS ${MIDL_COMMAND_SCRIPT}
+            COMMENT "Processing ${IDL_FILE}"
+            WORKING_DIRECTORY ${TARGET_SOURCE_DIR}
+        )
+
+        list(APPEND GENERATED_FILES ${MIDL_OUTPUT_FILES})
+    endforeach()
+
+    set(${MIDL_GENERATED_FILES} ${GENERATED_FILES} PARENT_SCOPE)
+endfunction()
+
+#----------------------------------------------------------------------------------------------------------------------
+#
+#----------------------------------------------------------------------------------------------------------------------
+function(_process_target_midl_1_0 TARGET)
+    get_target_property(TARGET_SOURCE_DIR ${TARGET} SOURCE_DIR)
+
+    get_target_property(IDL_FILES ${TARGET} SOURCES)
+    list(FILTER IDL_FILES INCLUDE REGEX "\.idl$")
+
+    # Run MIDL on every '.idl' file specified to the target.
+    _generateMidlOutput(${TARGET} ${IDL_FILES} MIDL_GENERATED_FILES)
+
+    target_include_directories(${TARGET}
+        PRIVATE
+            "${TARGET_SOURCE_DIR}"
+        PUBLIC
+            "${CMAKE_CURRENT_BINARY_DIR}/Generated Files"
+    )
+
+    target_sources(${TARGET}
+        PRIVATE
+            ${MIDL_GENERATED_FILES}
+    )
+endfunction()

--- a/Support/MidlRT.cmake
+++ b/Support/MidlRT.cmake
@@ -105,9 +105,10 @@ function(_generateUnmergedWinMd TARGET IDL_FILES WINMD_FILES_VARIABLE)
     list(APPEND MIDL_COMMAND "\"${MIDL_COMPILER}\"")
     list(APPEND MIDL_COMMAND "@\"${MIDL_PLATFORM_RESPONSE_FILE}\"")
     list(APPEND MIDL_COMMAND /winrt)
-    list(APPEND MIDL_COMMAND /W1)
+    list(APPEND MIDL_COMMAND /W3 /WX)
     list(APPEND MIDL_COMMAND /char signed)
     list(APPEND MIDL_COMMAND /env x64)
+    list(APPEND MIDL_COMMAND /error all)
     list(APPEND MIDL_COMMAND /h nul /dlldata nul /iid nul /proxy nul /notlb)
     list(APPEND MIDL_COMMAND /client none /server none)
     list(APPEND MIDL_COMMAND /enum_class)
@@ -121,14 +122,13 @@ function(_generateUnmergedWinMd TARGET IDL_FILES WINMD_FILES_VARIABLE)
     # COMPILER_DIR
     get_filename_component(COMPILER_DIR ${CMAKE_C_COMPILER} DIRECTORY)
 
-    set(WINMD_FILES)
+    set(GENERATED_FILES)
 
     foreach(IDL_FILE IN LISTS IDL_FILES)
         get_filename_component(IDL_FILE_BASE ${IDL_FILE} NAME_WLE)
+
         set(OUTPUT_WINMD_FILE ${CMAKE_CURRENT_BINARY_DIR}/Unmerged/${IDL_FILE_BASE}.winmd)
         set(OUTPUT_WINMD_LOG ${CMAKE_CURRENT_BINARY_DIR}/Unmerged/${IDL_FILE_BASE}.log)
-
-        list(APPEND WINMD_FILES ${OUTPUT_WINMD_FILE})
 
         cmake_path(NATIVE_PATH OUTPUT_WINMD_FILE OUTPUT_WINMD_FILE)
         cmake_path(NATIVE_PATH OUTPUT_WINMD_LOG OUTPUT_WINMD_LOG)
@@ -148,9 +148,11 @@ ${MIDL_COMMAND_LINE} /winmd \"${OUTPUT_WINMD_FILE}\" \"${IDL_FILE}\" /o \"${OUTP
             COMMENT "Generating ${IDL_FILE_BASE}.winmd"
             WORKING_DIRECTORY ${TARGET_SOURCE_DIR}
         )
+
+        list(APPEND GENERATED_FILES ${OUTPUT_WINMD_FILE})
     endforeach()
 
-    set(${WINMD_FILES_VARIABLE} ${WINMD_FILES} PARENT_SCOPE)
+    set(${WINMD_FILES_VARIABLE} ${GENERATED_FILES} PARENT_SCOPE)
 endfunction()
 
 #----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
When compiling a CMake project with a Visual Studio Generator, certain functionality is picked up from the built-in props/targets that are included by default by the generated project. To allow other generators to support that functionality, the support needs to be described on the "CMake-side", not the "Generator-build-side". And this PR adds a simple description of "non-WinRT MIDL" to the CMake-side. There's _some_ overlap with `MidlRT.cmake`, but enough differences that I've kept the support separate. I need to add an example, but I've been using this myself for a while that sending it out for general awareness seems reasonable