### PR TITLE
Add a trivial workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,10 @@
+name: Toolchain CI
+on:
+  workflow_dispatch:
+jobs:
+  build:
+    name: Build Examples
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2


### PR DESCRIPTION
In order to try out different workflows in a topic branch, there needs to be a workflow YAML file in the 'default' (i.e. main) branch. So this PR adds a simple, trivial workflow - it simply checks-out the repo.