### PR TITLE
Add a PR/CI workflow that builds the 'examples' folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @MarkSchofield

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,44 @@
 name: Toolchain CI
 on:
+  pull_request:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '.editorconfig'
+      - '.vscode/**'
+      - '*.md'
   workflow_dispatch:
 jobs:
   build:
     name: Build Examples
+    strategy:
+      max-parallel: 8
+      fail-fast: false
+      matrix:
+        configuration: [ Debug, Release ]
+        buildPreset: [ windows-msvc-x64, windows-msvc-x86, windows-msvc-arm64, windows-clang-x64 ]
     runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: CMake Configure ${{ matrix.buildPreset }}
+        shell: pwsh
+        run: |
+          Set-Location ./example
+          cmake --preset ${{ matrix.buildPreset }}
+      - name: CMake Build ${{ matrix.buildPreset }}
+        shell: pwsh
+        run: |
+          Set-Location ./example
+          cmake --build --preset ${{ matrix.buildPreset }} --config ${{ matrix.configuration }}
+      - name: Upload output artifact
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: __output_${{ matrix.buildPreset }}_${{ matrix.configuration }}
+          path: |
+            example/__output/${{ matrix.buildPreset }}
+            !example/__output/${{ matrix.buildPreset }}/**/*.ilk
+            !example/__output/${{ matrix.buildPreset }}/**/*.obj
+            !example/__output/${{ matrix.buildPreset }}/**/*.pch

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # A CMake Toolchain file for Windows MSVC and Windows Clang
 
 A CMake toolchain file describes the set of tools and utilities for compiling code in CMake. This repo provides
-toolchains that descibes how to compile using MSVC and Clang in CMake, with the goal of making Windows CMake builds more
+toolchains that describes how to compile using MSVC and Clang in CMake, with the goal of making Windows CMake builds more
 canonical to reduce the 'barrier-to-entry' to build code for Windows.
+
+[![build status](https://github.com/MarkSchofield/Toolchain/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/MarkSchofield/Toolchain/actions/workflows/ci.yaml?query=branch%3Amain)
+
 
 ## But I can build with MSVC in CMake already...?
 

--- a/example/CMakePresets.json
+++ b/example/CMakePresets.json
@@ -73,15 +73,6 @@
       }
     },
     {
-      "name": "windows-msvc-arm",
-      "inherits": "windows-msvc",
-      "displayName": "Configure for 'windows-msvc-arm'",
-      "binaryDir": "${sourceDir}/__output/${presetName}",
-      "cacheVariables": {
-        "CMAKE_SYSTEM_PROCESSOR": "arm"
-      }
-    },
-    {
       "name": "windows-clang-x64",
       "inherits": "windows-clang",
       "displayName": "Configure for 'windows-clang-x64'",
@@ -104,10 +95,6 @@
     {
       "name": "windows-msvc-arm64",
       "configurePreset": "windows-msvc-arm64"
-    },
-    {
-      "name": "windows-msvc-arm",
-      "configurePreset": "windows-msvc-arm"
     },
     {
       "name": "windows-clang-x64",

--- a/example/build.ps1
+++ b/example/build.ps1
@@ -5,8 +5,8 @@
 
 [CmdletBinding()]
 param (
-    [ValidateSet('windows-clang-x64', 'windows-msvc-arm', 'windows-msvc-arm64', 'windows-msvc-x64', 'windows-msvc-x86')]
-    $Presets = @('windows-clang-x64', 'windows-msvc-arm', 'windows-msvc-arm64', 'windows-msvc-x64', 'windows-msvc-x86')
+    [ValidateSet('windows-clang-x64', 'windows-msvc-arm64', 'windows-msvc-x64', 'windows-msvc-x86')]
+    $Presets = @('windows-clang-x64', 'windows-msvc-arm64', 'windows-msvc-x64', 'windows-msvc-x86')
 )
 
 Set-StrictMode -Version Latest


### PR DESCRIPTION
This PR addresses #21 and #22, and also adds a `.github/CODEOWNERS` file.

The `ci.yaml` specifies a GitHub Workflow that builds {Debug, Release} x { windows-msvc-x64, windows-msvc-x86, windows-msvc-arm64, windows-clang-x64 }. It simply checks-outs the repo, configures and builds the 'examples' folder and uploads the contents of the `CMAKE_BINARY_DIR` as an artifact (to capture logs for debugging as well as output). CMake errors break the build. The Artifact excludes intermediate files that aren't particularly useful, just to be thrifty with artifact upload/download.
