### PR TITLE
Add 'add_cppwinrt_projection' for creating a C++/WinRT projection target

### DIFF
--- a/Support/CppWinRT.cmake
+++ b/Support/CppWinRT.cmake
@@ -21,6 +21,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #----------------------------------------------------------------------------------------------------------------------
+cmake_minimum_required(VERSION 3.20)
+
 include_guard()
 
 include("${CMAKE_CURRENT_LIST_DIR}/../NuGet.cmake")
@@ -36,6 +38,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/../NuGet.cmake")
             [PCH_NAME <pch name>]
             [OPTIMIZE]
         )
+
+    Note: Deprecated. Use 'add_cppwinrt_projection' instead.
 ====================================================================================================================]]#
 function(generate_winrt_projection)
     set(OPTIONS OPTIMIZE)
@@ -82,4 +86,109 @@ function(generate_winrt_projection)
 
         message(VERBOSE "generate_winrt_projection: CPPWINRT_OUTPUT = ${CPPWINRT_OUTPUT}")
     endif()
+endfunction()
+
+#[[====================================================================================================================
+    add_cppwinrt_projection
+    -----------------------
+
+    Creates a target representing a C++/WinRT projection
+
+        add_cppwinrt_projection(<target>
+            INPUTS <spec>+
+            [VERSION <C++/WinRT version>]
+            [PROJECTION_ROOT_PATH <path>]
+            [OPTIMIZE]
+        )
+
+    The 'INPUTS' will be used to generate the projection, and can be any input to the cppwinrt tooling. If the INPUTS
+    includes a path to a .winmd file, the file will be a dependency of the target that generates the projection.
+
+    The VERSION parameter is optional, but if not specified the CPPWINRT_VERSION must be set.
+
+    The PROJECTION_ROOT_PATH is optional. If not specified, and CPPWINRT_PROJECTION_ROOT_PATH is set, then the value of
+    CPPWINRT_PROJECTION_ROOT_PATH will be used. If no value for PROJECTION_ROOT_PATH is specified, it will be defaulted
+    to `${CMAKE_BINARY_DIR}/__cppwinrt`. Note: It is recommended that a custom value is specified outside of
+    ${CMAKE_BINARY_DIR}, so that the same generated projection files can be used for all platforms and configurations.
+
+====================================================================================================================]]#
+function(add_cppwinrt_projection TARGET_NAME)
+    set(OPTIONS OPTIMIZE)
+    set(ONE_VALUE_KEYWORDS PROJECTION_ROOT_PATH VERSION PCH_NAME)
+    set(MULTI_VALUE_KEYWORDS INPUTS)
+
+    if(NOT TARGET_NAME)
+        message(FATAL_ERROR "add_cppwinrt_projection called with incorrect arguments: a target name is required.")
+    endif()
+
+    cmake_parse_arguments(PARSE_ARGV 1 CPPWINRT "${OPTIONS}" "${ONE_VALUE_KEYWORDS}" "${MULTI_VALUE_KEYWORDS}")
+
+    if(NOT CPPWINRT_VERSION)
+        message(FATAL_ERROR "add_cppwinrt_projection: CPPWINRT_VERSION must be specified.")
+    endif()
+
+    if(NOT CPPWINRT_PROJECTION_ROOT_PATH)
+        set(CPPWINRT_PROJECTION_ROOT_PATH ${CMAKE_BINARY_DIR}/__cppwinrt)
+    endif()
+
+    message(VERBOSE "add_cppwinrt_projection: CPPWINRT_VERSION = ${CPPWINRT_VERSION}")
+    message(VERBOSE "add_cppwinrt_projection: CPPWINRT_PROJECTION_ROOT_PATH = ${CPPWINRT_PROJECTION_ROOT_PATH}")
+
+    # Install the Microsoft.Windows.CppWinRT NuGet
+    install_nuget_package(Microsoft.Windows.CppWinRT ${CPPWINRT_VERSION} NUGET_MICROSOFT_WINDOWS_CPPWINRT)
+
+    # Build the command to generate the projection
+    set(CPPWINRT_OUTPUT ${CPPWINRT_PROJECTION_ROOT_PATH}/${TARGET_NAME})
+    set(CPPWINRT_OUTPUT_FILE ${CPPWINRT_OUTPUT}/output.log)
+    set(CPPWINRT_EXECUTABLE_PATH ${NUGET_MICROSOFT_WINDOWS_CPPWINRT}/bin/cppwinrt.exe)
+
+    set(CPPWINRT_COMMAND)
+    list(APPEND CPPWINRT_COMMAND ${CPPWINRT_EXECUTABLE_PATH})
+    list(APPEND CPPWINRT_COMMAND -output ${CPPWINRT_OUTPUT})
+    list(APPEND CPPWINRT_COMMAND -input ${CPPWINRT_INPUTS})
+
+    if(CPPWINRT_OPTIMIZE)
+        list(APPEND CPPWINRT_COMMAND -optimize)
+    endif()
+
+    list(APPEND CPPWINRT_COMMAND > ${CPPWINRT_OUTPUT_FILE})
+
+    # Check 'CPPWINRT_INPUTS', if the items are none of:
+    #   * local
+    #   * sdk[+]
+    #   * 10.0.12345.0[+]
+    # add it as a dependency.
+    set(CPPWINRT_DEPENDS)
+    foreach(CPPWINRT_INPUT IN LISTS CPPWINRT_INPUTS)
+        if((CPPWINRT_INPUT STREQUAL "local") OR
+            (CPPWINRT_INPUT MATCHES [[^sdk\+?$]]) OR
+            (CPPWINRT_INPUT MATCHES [[^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+\+?$]]))
+            message(VERBOSE "add_cppwinrt_projection: CPPWINRT_INPUT = ${CPPWINRT_INPUT}")
+            continue()
+        endif()
+        message(VERBOSE "add_cppwinrt_projection: CPPWINRT_INPUT = ${CPPWINRT_INPUT} (dependency)")
+        list(APPEND CPPWINRT_DEPENDS ${CPPWINRT_INPUT})
+    endforeach()
+
+    add_custom_command(
+        OUTPUT ${CPPWINRT_OUTPUT_FILE}
+        COMMAND ${CPPWINRT_COMMAND}
+        DEPENDS ${CPPWINRT_DEPENDS}
+        COMMENT "Generating C++/WinRT Projection - ${TARGET_NAME}"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+
+    add_library(${TARGET_NAME} INTERFACE
+        ${CPPWINRT_OUTPUT_FILE}
+    )
+
+    target_include_directories(${TARGET_NAME} BEFORE
+        INTERFACE
+            ${CPPWINRT_OUTPUT}
+    )
+
+    target_link_libraries(${TARGET_NAME}
+        INTERFACE
+            RuntimeObject.lib
+    )
 endfunction()

--- a/Support/CppWinRT.cmake
+++ b/Support/CppWinRT.cmake
@@ -25,12 +25,6 @@ include_guard()
 
 include("${CMAKE_CURRENT_LIST_DIR}/../NuGet.cmake")
 
-if(NOT CPPWINRT_VERSION)
-    set(CPPWINRT_VERSION "2.0.210930.14")
-endif()
-
-install_nuget_package(Microsoft.Windows.CppWinRT ${CPPWINRT_VERSION} NUGET_MICROSOFT_WINDOWS_CPPWINRT)
-
 #[[====================================================================================================================
     generate_winrt_projection
     -------------------------
@@ -49,6 +43,12 @@ function(generate_winrt_projection)
     set(MULTI_VALUE_KEYWORDS INPUT)
 
     cmake_parse_arguments(PARSE_ARGV 0 CPPWINRT "${OPTIONS}" "${ONE_VALUE_KEYWORDS}" "${MULTI_VALUE_KEYWORDS}")
+
+    if(NOT CPPWINRT_VERSION)
+        set(CPPWINRT_VERSION "2.0.210930.14")
+    endif()
+
+    install_nuget_package(Microsoft.Windows.CppWinRT ${CPPWINRT_VERSION} NUGET_MICROSOFT_WINDOWS_CPPWINRT)
 
     if(NOT CPPWINRT_PROJECTION_ROOT_PATH)
         set(CPPWINRT_PROJECTION_ROOT_PATH ${CMAKE_BINARY_DIR}/__cppwinrt)

--- a/Support/MidlRT.cmake
+++ b/Support/MidlRT.cmake
@@ -24,6 +24,13 @@
 include_guard()
 
 include("${CMAKE_CURRENT_LIST_DIR}/../PowerShell.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/../NuGet.cmake")
+
+if(NOT CPPWINRT_VERSION)
+    set(CPPWINRT_VERSION "2.0.210930.14")
+endif()
+
+install_nuget_package(Microsoft.Windows.CppWinRT ${CPPWINRT_VERSION} NUGET_MICROSOFT_WINDOWS_CPPWINRT)
 
 set(MIDL_PLATFORM_RESPONSE_FILE "${CMAKE_BINARY_DIR}/midl.platform.rsp")
 set(MDMERGE_PLATFORM_RESPONSE_FILE "${CMAKE_BINARY_DIR}/mdmerge.platform.rsp")

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -7,12 +7,11 @@ project(WindowsToolchainExample)
 
 include(CppWinRT)
 
-generate_winrt_projection(
-    INPUT local
+add_cppwinrt_projection(CppWinRT
+    INPUTS
+        ${CMAKE_SYSTEM_VERSION}
     OPTIMIZE
 )
-
-include_directories(BEFORE SYSTEM ${CPPWINRT_PROJECTION_ROOT_PATH})
 
 add_compile_definitions(
     UNICODE

--- a/example/CommandLineWinRT/CMakeLists.txt
+++ b/example/CommandLineWinRT/CMakeLists.txt
@@ -19,7 +19,5 @@ target_precompile_headers(CommandLineWinRT
 
 target_link_libraries(CommandLineWinRT
     PRIVATE
-        RuntimeObject.lib
-        oleaut32.lib
-        ole32.lib
+        CppWinRT
 )

--- a/example/RuntimeComponent/CMakeLists.txt
+++ b/example/RuntimeComponent/CMakeLists.txt
@@ -22,4 +22,9 @@ target_precompile_headers(RuntimeComponent
         pch.h
 )
 
+target_link_libraries(RuntimeComponent
+    PRIVATE
+        CppWinRT
+)
+
 enable_midlrt(RuntimeComponent)


### PR DESCRIPTION
This PR revisits the C++/WinRT integration to make it more idiomatically CMake-ish. The original implementation - `generate_winrt_projection` - was a simple function that would run the C++/WinRT tooling to make a projection during CMake generation. It was awkward to get details out of how to consume the projection (#30), it relied on implicit contract with the consumer (#18), and it didn't regenerate the projection when an input winmd would change (#31). To address these problems, I'm adding `add_cppwinrt_projection` which makes a couple of important changes:

1. It takes the name of a target to create, that the consumer can specify in `target_link_libraries`. By creating a target, the details of the projection are encapsulated away from the consumer. Include paths, libraries and settings can be specified on the library, without the consumer having to know the gory details.
2. It moves the invocation of the C++/WinRT tooling from 'generate'-time to 'build'-time. This makes it much easier to describe dependencies and have the tooling re-run when the dependencies change. And - as an added bonus - it makes things faster: the 'generate' phase does less work, and the work that's done at build-time can happen in parallel with other build-things that are happening. And if a user is building a target that doesn't need a projection, then it won't be generated.