### PR TITLE
Better encapsulation of implementation details

### DIFF
--- a/PowerShell.cmake
+++ b/PowerShell.cmake
@@ -1,14 +1,33 @@
+#----------------------------------------------------------------------------------------------------------------------
+# MIT License
+#
+# Copyright (c) 2021 Mark Schofield
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#----------------------------------------------------------------------------------------------------------------------
+include_guard()
 
-find_program(
-    POWERSHELL_PATH
-    NAMES
-        pwsh.exe powershell.exe
-    DOC "The path to PowerShell"
-)
+include("${CMAKE_CURRENT_LIST_DIR}/ToolchainCommon.cmake")
 
 #[[====================================================================================================================
     execute_powershell
-    -------------------------
+    ------------------
     Executes the given PowerShell script.
 
         execute_powershell(
@@ -17,6 +36,8 @@ find_program(
         )
 ====================================================================================================================]]#
 function(execute_powershell INLINE_SCRIPT)
+    toolchain_find_powershell(POWERSHELL_PATH)
+
     set(OPTIONS)
     set(ONE_VALUE_KEYWORDS OUTPUT_VARIABLE)
     set(MULTI_VALUE_KEYWORDS)
@@ -28,7 +49,7 @@ function(execute_powershell INLINE_SCRIPT)
     cmake_parse_arguments(PARSE_ARGV 0 EXECUTE_POWERSHELL "${OPTIONS}" "${ONE_VALUE_KEYWORDS}" "${MULTI_VALUE_KEYWORDS}")
 
     set(POWERSHELL_COMMAND ${POWERSHELL_PATH} -ExecutionPolicy RemoteSigned -NoProfile -NonInteractive)
-    list(APPEND POWERSHELL_COMMAND  -Command ${INLINE_SCRIPT})
+    list(APPEND POWERSHELL_COMMAND -Command ${INLINE_SCRIPT})
 
     message(VERBOSE "POWERSHELL_COMMAND = ${POWERSHELL_COMMAND}")
     execute_process(

--- a/ToolchainCommon.cmake
+++ b/ToolchainCommon.cmake
@@ -54,6 +54,32 @@ function(toolchain_update_file)
 endfunction()
 
 #[[====================================================================================================================
+    toolchain_find_powershell
+    -------------------------
+    Searches for PowerShell.
+
+        toolchain_find_powershell(
+            <VARIABLE_NAME>
+        )
+
+    If the POWERSHELL_PATH value is set, that will be preferred. The VARIABLE_NAME will be set in the parent scope
+    with the result.
+====================================================================================================================]]#
+function(toolchain_find_powershell VARIABLE_NAME)
+    if(NOT EXISTS ${POWERSHELL_PATH})
+        find_program(
+            POWERSHELL_PATH
+            NAMES
+                pwsh.exe powershell.exe
+            DOC "The path to PowerShell"
+            REQUIRED
+        )
+    endif()
+    message(VERBOSE "toolchain_find_powershell: Using PowerShell from: ${POWERSHELL_PATH}")
+    set(${VARIABLE_NAME} ${POWERSHELL_PATH} PARENT_SCOPE)
+endfunction()
+
+#[[====================================================================================================================
     toolchain_download_file
     -----------------------
     Downloads a file to the given path.

--- a/VSWhere.cmake
+++ b/VSWhere.cmake
@@ -58,12 +58,6 @@ if(VSWHERE_PATH STREQUAL "VSWHERE_PATH-NOTFOUND")
     )
 endif()
 
-function(getVSWhereProperty VSWHERE_OUTPUT VSWHERE_PROPERTY VARIABLE_NAME)
-    string(REGEX MATCH "${VSWHERE_PROPERTY}: [^\r\n]*" VSWHERE_VALUE "${VSWHERE_OUTPUT}")
-    string(REPLACE "${VSWHERE_PROPERTY}: " "" VSWHERE_VALUE "${VSWHERE_VALUE}")
-    set(${VARIABLE_NAME} "${VSWHERE_VALUE}" PARENT_SCOPE)
-endfunction()
-
 #[[====================================================================================================================
     findVisualStudio
     ----------------
@@ -112,6 +106,12 @@ function(findVisualStudio)
         )
 
     message(VERBOSE "findVisualStudio: VSWHERE_OUTPUT = ${VSWHERE_OUTPUT}")
+
+    function(getVSWhereProperty VSWHERE_OUTPUT VSWHERE_PROPERTY VARIABLE_NAME)
+        string(REGEX MATCH "${VSWHERE_PROPERTY}: [^\r\n]*" VSWHERE_VALUE "${VSWHERE_OUTPUT}")
+        string(REPLACE "${VSWHERE_PROPERTY}: " "" VSWHERE_VALUE "${VSWHERE_VALUE}")
+        set(${VARIABLE_NAME} "${VSWHERE_VALUE}" PARENT_SCOPE)
+    endfunction()
 
     while(FIND_VS_PROPERTIES)
         list(POP_FRONT FIND_VS_PROPERTIES VSWHERE_PROPERTY)


### PR DESCRIPTION
Iterating on some simple cleanup:
1. ~~`toolchain_update_file` is equivalent to `file(GENERATE...`, switching over to have less code and to be more idiomatic.~~
2. `PowerShell.cmake` shouldn't always `find_program` for PowerShell; move the call into `execute_powershell`.
3. Move `getVSWhereProperty` into `findVisualStudio` to reduce the exposed surface area of `VSWhere.cmake`

In my self-hosting, item (1) was causing all sorts of breaks - I'm removing that commit until I understand it better.