### PR TITLE
Enable creating cppwinrt projections with dependencies

### DIFF
--- a/example/CommandLineWinRT/CMakeLists.txt
+++ b/example/CommandLineWinRT/CMakeLists.txt
@@ -19,5 +19,10 @@ target_precompile_headers(CommandLineWinRT
 
 target_link_libraries(CommandLineWinRT
     PRIVATE
-        CppWinRT
+        RuntimeComponentCppWinRT
+)
+
+add_custom_command(TARGET CommandLineWinRT POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:CommandLineWinRT> $<TARGET_FILE_DIR:CommandLineWinRT>
+  COMMAND_EXPAND_LISTS
 )

--- a/example/CommandLineWinRT/main.cpp
+++ b/example/CommandLineWinRT/main.cpp
@@ -3,6 +3,7 @@
 //---------------------------------------------------------------------------------------------------------------------
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Web.Syndication.h>
+#include <winrt/RuntimeComponent.h>
 #include <iostream>
 
 using namespace winrt;
@@ -12,6 +13,10 @@ using namespace Windows::Web::Syndication;
 int main()
 {
     winrt::init_apartment();
+
+    RuntimeComponent::Class c;
+    c.MyProperty(42);
+    std::wcout << "c.MyProperty() = " << c.MyProperty() << std::endl;
 
     Uri rssFeedUri{ L"https://blogs.windows.com/feed" };
     SyndicationClient syndicationClient;

--- a/example/RuntimeComponent/CMakeLists.txt
+++ b/example/RuntimeComponent/CMakeLists.txt
@@ -28,3 +28,16 @@ target_link_libraries(RuntimeComponent
 )
 
 enable_midlrt(RuntimeComponent)
+
+add_cppwinrt_projection(RuntimeComponentCppWinRT
+    INPUTS
+        ${CMAKE_CURRENT_BINARY_DIR}/RuntimeComponent.winmd
+    DEPS
+        CppWinRT
+    OPTIMIZE
+)
+
+target_link_libraries(RuntimeComponentCppWinRT
+    INTERFACE
+        RuntimeComponent
+)

--- a/example/RuntimeComponent/Class.cpp
+++ b/example/RuntimeComponent/Class.cpp
@@ -6,11 +6,11 @@ namespace winrt::RuntimeComponent::implementation
 {
     int32_t Class::MyProperty()
     {
-        throw hresult_not_implemented();
+        return m_myProperty;
     }
 
-    void Class::MyProperty(int32_t /* value */)
+    void Class::MyProperty(int32_t value)
     {
-        throw hresult_not_implemented();
+        m_myProperty = value;
     }
 }

--- a/example/RuntimeComponent/Class.h
+++ b/example/RuntimeComponent/Class.h
@@ -10,6 +10,8 @@ namespace winrt::RuntimeComponent::implementation
 
         int32_t MyProperty();
         void MyProperty(int32_t value);
+
+        int32_t m_myProperty = 0;
     };
 }
 


### PR DESCRIPTION
Cppwinrt projections need not be global (i.e. all components plus the SDK); they may be generated for individual components if their dependencies are listed with the `-ref` parameter. This enables the projection of the SDK itself to be re-used by various other components rather than each component's projection replicating the SDK projection as well. These dependencies may chain as well if component A references types from component B, which both reference types from the SDK (for example).

This change introduces a `DEPS` parameter to `add_cppwinrt_projection` to facilitate this usage, as well as limited support for direct chaining of dependencies via a target property, `INTERFACE_CPPWINRT_REFS`. Dependencies are specified as CMake targets, and will also be added to `target_link_libs` for the resulting projection's target so that include paths, etc. for all the referenced components resolve correctly.

To demonstrate and validate this, the examples have been updated to show consuming a WinRT component from another target, including copying the implementation DLLs into the binary folder so the executable will run correctly.