### PR TITLE
'CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION' shouldn't be limited by host OS version

### DIFF
--- a/Windows.Kits.cmake
+++ b/Windows.Kits.cmake
@@ -22,12 +22,13 @@
 # SOFTWARE.
 #----------------------------------------------------------------------------------------------------------------------
 #
-# | CMake Variable                                      | Description                                                                                                              |
-# |-----------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
-# | CMAKE_SYSTEM_VERSION                                | The version of the operating system for which CMake is to build. Defaults to the host version.                           |
-# | CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE         | The architecture of the tooling to use. Defaults to x64.                                                                 |
-# | CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION            | The version of the Windows SDK to use. Defaults to the highest installed, that is no higher than the host OS version.    |
-# | CMAKE_WINDOWS_KITS_10_DIR                           | The location of the root of the Windows Kits 10 directory.                                                               |
+# | CMake Variable                                      | Description                                                                                                                                       |
+# |-----------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+# | CMAKE_SYSTEM_VERSION                                | The version of the operating system for which CMake is to build. Defaults to the host version.                                                    |
+# | CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE         | The architecture of the tooling to use. Defaults to x64.                                                                                          |
+# | CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION            | The version of the Windows SDK to use. Defaults to the highest installed, that is no higher than CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM |
+# | CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM    | The maximum version of the Windows SDK to use, for example '10.0.19041.0'. Defaults to nothing                                                    |
+# | CMAKE_WINDOWS_KITS_10_DIR                           | The location of the root of the Windows Kits 10 directory.                                                                                        |
 #
 # The following variables will be set:
 #
@@ -69,10 +70,23 @@ if(NOT CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION)
     list(SORT WINDOWS_KITS_VERSIONS COMPARE NATURAL ORDER DESCENDING)
     while(WINDOWS_KITS_VERSIONS)
         list(POP_FRONT WINDOWS_KITS_VERSIONS CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION)
-        if(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION VERSION_LESS_EQUAL CMAKE_HOST_SYSTEM_VERSION)
+        if(NOT CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM)
+            message(VERBOSE "Windows.Kits: Defaulting version: ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
             break()
         endif()
+
+        if(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION VERSION_LESS_EQUAL CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM)
+            message(VERBOSE "Windows.Kits: Choosing version: ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
+            break()
+        endif()
+
+        message(VERBOSE "Windows.Kits: Not suitable: ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
+        set(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION)
     endwhile()
+endif()
+
+if(NOT CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION)
+    message(FATAL_ERROR "A Windows SDK could not be found.")
 endif()
 
 set(WINDOWS_KITS_BIN_PATH "${CMAKE_WINDOWS_KITS_10_DIR}/bin/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}" CACHE PATH "" FORCE)

--- a/example/CMakePresets.json
+++ b/example/CMakePresets.json
@@ -14,6 +14,7 @@
         "NUGET_PACKAGE_ROOT_PATH": "${sourceDir}/__packages",
         "CPPWINRT_VERSION": "2.0.210930.14",
         "CPPWINRT_PROJECTION_ROOT_PATH": "${sourceDir}/__cppwinrt",
+        "CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM": "10.0.19041.0",
         "CMAKE_SYSTEM_VERSION": "10.0.19041.0"
       }
     },


### PR DESCRIPTION
`Windows.Kits.cmake` contains logic that it shouldn't choose a Windows SDK that is higher that the host OS version. That logic isn't sound, Windows SDK's are supported on older OS's, so removing the 'host OS' version check. I did notice that CMake has support for `CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM` ([documentation](https://cmake.org/cmake/help/latest/variable/CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM.html)) so added support to respect that variable to allow consumers to set a ceiling on SDK versions.

This addresses #34.