### PR TITLE
Set CMAKE_<LANG>_COMPILER_PREDEFINES_COMMAND in Windows.MSVC.toolchain.cmake

### DIFF
--- a/Windows.MSVC.toolchain.cmake
+++ b/Windows.MSVC.toolchain.cmake
@@ -262,7 +262,7 @@ if( (CMAKE_GENERATOR MATCHES "^Ninja") AND
     list(APPEND CMAKE_SYSTEM_PROGRAM_PATH "${VS_INSTALLATION_PATH}/Common7/IDE/CommonExtensions/Microsoft/CMake/Ninja")
 endif()
 
-# Generate moc_predefs.h file for automoc
+# Set 'CMAKE_<LANG>_COMPILER_PREDEFINES_COMMAND' to allow consumers - like automoc - to obtain the compiler predefines.
 #
 set(CMAKE_CXX_COMPILER_PREDEFINES_COMMAND
     ${CMAKE_CXX_COMPILER}
@@ -270,5 +270,16 @@ set(CMAKE_CXX_COMPILER_PREDEFINES_COMMAND
         /Zc:preprocessor
         /PD
         /c
+        /Fonul.
         ${CMAKE_ROOT}/Modules/CMakeCXXCompilerABI.cpp
+)
+
+set(CMAKE_C_COMPILER_PREDEFINES_COMMAND
+    ${CMAKE_C_COMPILER}
+        /nologo
+        /Zc:preprocessor
+        /PD
+        /c
+        /Fonul.
+        ${CMAKE_ROOT}/Modules/CMakeCCompilerABI.c
 )


### PR DESCRIPTION
Setting "CMAKE_<LANG>_COMPILER_PREDEFINES_COMMAND" with the command that will produce the compiler's predefines unblocks downstream consumers, like 'automoc'.