### PR TITLE
Update VS generators to Windows SDK 10.0.26100.0; allow Toolchain to find 10.0.26100.0

### DIFF
--- a/example/CMakePresets.json
+++ b/example/CMakePresets.json
@@ -10,7 +10,7 @@
       "name": "windows",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM": "10.0.22621.0",
+        "CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM": "10.0.26100.0",
         "CMAKE_SYSTEM_VERSION": "10.0.19041.0"
       }
     },
@@ -156,7 +156,7 @@
       "displayName": "windows-vs-x64",
       "description": "This build is only available on Windows",
       "cacheVariables": {
-        "CMAKE_GENERATOR_PLATFORM": "x64,version=10.0.22621.0",
+        "CMAKE_GENERATOR_PLATFORM": "x64,version=10.0.26100.0",
         "CMAKE_SYSTEM_PROCESSOR": "AMD64"
       }
     },
@@ -168,7 +168,7 @@
       "displayName": "windows-vs-arm64",
       "description": "This build is only available on Windows",
       "cacheVariables": {
-        "CMAKE_GENERATOR_PLATFORM": "ARM64,version=10.0.22621.0",
+        "CMAKE_GENERATOR_PLATFORM": "ARM64,version=10.0.26100.0",
         "CMAKE_SYSTEM_PROCESSOR": "ARM64"
       }
     }


### PR DESCRIPTION
The GitHub Actions Agents appear to have been updated - the latest inventory of installed software is [here](https://github.com/actions/runner-images/blob/win25/20251021.67/images/windows/Windows2025-Readme.md), showing that only the `10.0.26100.0` Windows SDK is installed. The `:/example/CMakePresets.json` won't pick up that version of the Windows SDK:
1. The presets that use a Visual Studio Generator specify `CMAKE_GENERATOR_PLATFORM` with `version=10.0.22621.0`, so it will only use Windows SDK version `10.0.22621.0`.
2. The presets that use WindowsToolchain set `CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM` to `10.0.22621.0`, which won't allow `10.0.26100.0`.

This PR simply updates values so that both cases now allow the `10.0.26100.0` Windows SDK.