### PR TITLE
Fixes to 'Windows.EWDK.toolchain.cmake'

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -38,7 +38,7 @@ add_subdirectory(CommandLineC)
 add_subdirectory(SharedLibrary)
 add_subdirectory(WindowsApplication)
 
-if((CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") AND (CMAKE_SYSTEM_PROCESSOR STREQUAL AMD64))
+if((CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") AND (CMAKE_SYSTEM_PROCESSOR STREQUAL AMD64) AND (NOT EWDK))
     if(DEFINED ENV{CUDA_PATH})
         add_subdirectory(CommandLineCuda)
     else()

--- a/example/CMakePresets.json
+++ b/example/CMakePresets.json
@@ -135,7 +135,8 @@
         "VS_EXPERIMENTAL_MODULE": "OFF",
         "VS_USE_SPECTRE_MITIGATION_RUNTIME": "OFF"
       },
-      "binaryDir": "${sourceDir}/__output/${presetName}-$env{VSCMD_ARG_TGT_ARCH}"
+      "binaryDir": "${sourceDir}/__output/${presetName}-$env{VSCMD_ARG_TGT_ARCH}",
+      "condition": { "lhs": "$env{VSCMD_ARG_TGT_ARCH}", "type": "notEquals", "rhs": "" }
     },
     {
       "name": "windows-vs",


### PR DESCRIPTION
Fixes #136.

As `Windows.MSVC.toolchain.cmake` has been cleaned-up and improved over time it canonicalized supported `CMAKE_SYSTEM_PROCESSOR` values and - inadvertently broke `Windows.EWDK.toolchain.cmake`. Since GitHub runners don't have the EWDK installed, and don't have enough free space to install the EWDK, then it's tricky to catch such regressions. This change fixes things, making a few changes:
1. Rather than setting `CMAKE_SYSTEM_PROCESSOR` to `$ENV{VSCMD_ARG_TGT_ARCH}`, I'm checking `$ENV{VSCMD_ARG_TGT_ARCH}` and setting `CMAKE_SYSTEM_PROCESSOR` to the correct value.
2. If the `$ENV{VSCMD_ARG_TGT_ARCH}` corresponds to a matching `CMAKE_HOST_SYSTEM_PROCESSOR`, then `CMAKE_SYSTEM_PROCESSOR` **isn't** set to avoid 'cross-compiling'.
3. This change set EWDK to 1 to denote that EWDK is being used.
4. If EWDK is set, then the CUDA examples aren't compiled; they don't appear to work with the EWDK.
5. I'm adding a 'condition' to the 'ewdk' example preset so that it's excluded unless CMake is being run from an EWDK prompt.

I validated with the "EWDK_ge_release_svc_prod1_26100_250904-1728.iso" EWDK. I mounted the ISO to E: and ran:

```cmake
& cmd /c "E:\BuildEnv\SetupBuildEnv.cmd x86 && set && cmake --preset ewdk && cmake --build --preset ewdk"
& cmd /c "E:\BuildEnv\SetupBuildEnv.cmd x86_arm64 && set && cmake --preset ewdk && cmake --build --preset ewdk"
& cmd /c "E:\BuildEnv\SetupBuildEnv.cmd amd64 && set && cmake --preset ewdk && cmake --build --preset ewdk"
```
