### PR TITLE
Update CMAKE_VS_VERSION_RANGE to '[16.0,19.0)' to include VS2026

### DIFF
--- a/example/CMakePresets.json
+++ b/example/CMakePresets.json
@@ -23,6 +23,7 @@
       "generator": "Ninja Multi-Config",
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": "../Windows.MSVC.toolchain.cmake",
+        "CMAKE_VS_VERSION_RANGE": "[16.0,19.0)",
         "CMAKE_VS_VERSION_PRERELEASE": "ON",
         "VS_EXPERIMENTAL_MODULE": "OFF",
         "VS_USE_SPECTRE_MITIGATION_ATLMFC_RUNTIME": "OFF",
@@ -49,7 +50,7 @@
       "generator": "Ninja Multi-Config",
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": "../Windows.Clang.toolchain.cmake",
-        "CMAKE_VS_VERSION_RANGE": "[16.0,18.0)",
+        "CMAKE_VS_VERSION_RANGE": "[16.0,19.0)",
         "CMAKE_VS_VERSION_PRERELEASE": "ON"
       }
     },


### PR DESCRIPTION
By setting `CMAKE_VS_VERSION_RANGE` to `[16.0,19.0)` then WindowsToolchain's use of `vswhere.exe` will find VS2026.