### PR TITLE
Use 'winget' to install cuda

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,8 @@ jobs:
         if: ${{ matrix.cuda }}
         shell: pwsh
         run: |
-          choco install cuda
+          winget install Nvidia.CUDA --silent --accept-source-agreements --accept-package-agreements |
+            Select-String -NotMatch '^   [\\\-/|] $'
 
           # The installation sets the CUDA_PATH environment variable - use 'Update-SessionEnvironment' to pull it into
           # the current process' environment block, then add it to the '$env:GITHUB_ENV' file for subsequent steps.


### PR DESCRIPTION
`.github/workflows/ci.yaml` currently uses `choco install cuda` to install the Nvidia Cuda toolkit, but only installs v12.9.1.576. WinGet also has the Nvidia Cuda toolkit, but has v13.1.1. In order to stay up-to-date with the latest builds, the workflow should switch from choco to winget.