### PR TITLE
Windows.Clang.toolchain.cmake should accommodate VS_INSTALLATION_PATH being set

### DIFF
--- a/Windows.MSVC.toolchain.cmake
+++ b/Windows.MSVC.toolchain.cmake
@@ -36,8 +36,8 @@
 # | CMAKE_VS_VERSION_PRERELEASE                 | Whether 'prerelease' versions of Visual Studio should be considered. Defaults to 'OFF'                                   |
 # | CMAKE_VS_VERSION_RANGE                      | A verson range for VS instances to find. For example, '[16.0,17.0)' will find versions '16.*'. Defaults to '[16.0,17.0)' |
 # | CMAKE_WINDOWS_KITS_10_DIR                   | The location of the root of the Windows Kits 10 directory.                                                               |
-# | TOOLCHAIN_UPDATE_PROGRAM_PATH               | Whether the toolchain should update CMAKE_PROGRAM_PATH. Defaults to 'ON'.                                                |
 # | TOOLCHAIN_ADD_VS_NINJA_PATH                 | Whether the toolchain should add the path to the VS Ninja to the CMAKE_SYSTEM_PROGRAM_PATH. Defaults to 'ON'.            |
+# | TOOLCHAIN_UPDATE_PROGRAM_PATH               | Whether the toolchain should update CMAKE_PROGRAM_PATH. Defaults to 'ON'.                                                |
 # | VS_EXPERIMENTAL_MODULE                      | Whether experimental module support should be enabled.                                                                   |
 # | VS_INSTALLATION_PATH                        | The location of the root of the Visual Studio installation. If not specified VSWhere will be used to search for one.     |
 # | VS_PLATFORM_TOOLSET_VERSION                 | The version of the MSVC toolset to use. For example, 14.29.30133. Defaults to the highest available.                     |
@@ -54,9 +54,10 @@
 # | CMAKE_RC_COMPILER                           | The path tp the 'rc.exe' tool to use.                                                                 |
 # | CMAKE_SYSTEM_NAME                           | "Windows", when cross-compiling                                                                       |
 # | CMAKE_VS_PLATFORM_TOOLSET_VERSION           | The version of the MSVC toolset being used - e.g. 14.29.30133.                                        |
-# | WIN32                                       | 1                                                                                                     |
 # | MSVC                                        | 1                                                                                                     |
 # | MSVC_VERSION                                | The '<major><minor>' version of the C++ compiler being used. For example, '1929'                      |
+# | VS_INSTALLATION_PATH                        | The location of the root of the Visual Studio installation.                                           |
+# | WIN32                                       | 1                                                                                                     |
 #
 # Other configuration:
 #


### PR DESCRIPTION
#148 asks for support for (if I'm following correctly) `Windows.Clang.toolchain.cmake` to accommodate `VS_INSTALLATION_PATH` already being set, so that a Visual Studio instance can be found purely by path - much like in the EWDK use-case. This PR makes that change, and canonicalizes the documentation a little - for both `Windows.Clang.toolchain.cmake` and `Windows.MSVC.toolchain.cmake` the variables are sorted, and a couple of missing items added.