### PR TITLE
Fixes to the CI build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
         if: ${{ matrix.cuda }}
         shell: pwsh
         run: |
-          winget install Nvidia.CUDA --silent --accept-source-agreements --accept-package-agreements |
+          winget install Nvidia.CUDA --source winget --silent --accept-source-agreements --accept-package-agreements |
             Select-String -NotMatch '^   [\\\-/|] $'
 
           # The installation sets the CUDA_PATH environment variable - use 'Update-SessionEnvironment' to pull it into

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,10 @@ jobs:
             runner: windows-2025-vs2026
           - buildPreset: windows-vs2026-arm64
             runner: windows-2025-vs2026
+          - buildPreset: windows-vs2022-x64
+            runner: windows-2022
+          - buildPreset: windows-vs2022-arm64
+            runner: windows-2022
           - buildPreset: windows-ninja-msvc-x64
             cuda: true
           - buildPreset: windows-fastbuild-msvc-x64

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,8 +79,9 @@ jobs:
         run: |
           ./example/Scripts/updateCMake.ps1
 
-          $DownloadFolder = ./example/Scripts/installFASTBuild.ps1
+          $DownloadFolder = ./example/Scripts/installFASTBuild.ps1 -Verbose
           echo $DownloadFolder >> $env:GITHUB_PATH
+          exit 0
       - name: Build - ${{ matrix.buildPreset }}, ${{ matrix.configuration }}
         shell: pwsh
         run: |

--- a/example/Scripts/installFASTBuild.ps1
+++ b/example/Scripts/installFASTBuild.ps1
@@ -9,15 +9,26 @@ param (
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+$InformationPreference = 'Continue'
 
-$FastBuildVersion = "1.19"
+Write-Information "Downloading FASTBuild"
+
+$FastBuildVersion = '1.20'
+$FastBuildHash = 'FA44C85E037AFF4B8487237D9907F18A31B62E60423A806E5B2F30BD1B61865F'
+
 $FastBuildFileName = "FASTBuild-Windows-x64-v$FastBuildVersion.zip"
 $FastBuildZipUrl = "https://www.fastbuild.org/downloads/v$FastBuildVersion/$FastBuildFileName"
 $DownloadFolder = Join-Path -Path $PSScriptRoot -ChildPath "../../__downloads"
 $DownloadFile = Join-Path -Path $DownloadFolder -ChildPath $FastBuildFileName
 
 $null = mkdir -Path $DownloadFolder -Force
-Invoke-WebRequest -Uri $FastBuildZipUrl -OutFile $DownloadFile
-Expand-Archive -Path $DownloadFile -DestinationPath $DownloadFolder -Force
+$null = Invoke-WebRequest -Uri $FastBuildZipUrl -OutFile $DownloadFile
+
+$ActualHash = (Get-FileHash -Algorithm SHA256 -Path $DownloadFile | Select-Object -ExpandProperty Hash)
+if ($FastBuildHash -ne $ActualHash) {
+    Write-Error "Downloaded file does not match expected hash.`n`tExpected: $FastBuildHash`n`tActual:   $ActualHash"
+}
+
+$null = Expand-Archive -Path $DownloadFile -DestinationPath $DownloadFolder -Force
 
 $DownloadFolder

--- a/example/Scripts/updateCMake.ps1
+++ b/example/Scripts/updateCMake.ps1
@@ -10,4 +10,4 @@ param (
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-& winget upgrade kitware.cmake --verbose --accept-source-agreements --disable-interactivity
+& winget upgrade kitware.cmake --source winget --verbose --accept-source-agreements --disable-interactivity


### PR DESCRIPTION
Some fixes (#164, #165) to the CI build:
1. VS2022 builds should use the 'windows-2022' GitHub Action Runner
2. 'winget install' commands should specify '--source winget' to avoid 'msstore' dependency
3. Migrate to FASTBuild 1.20 (from 1.19)
4. Validate the SHA256 hash of the FASTBuild download